### PR TITLE
Follow-Up to Issue: Extra UI Options 

### DIFF
--- a/ios_calendar/Sources/CalendarView.h
+++ b/ios_calendar/Sources/CalendarView.h
@@ -59,6 +59,8 @@ typedef NS_ENUM(NSInteger, CalendarEvent)
 - (instancetype)initWithPosition:(CGFloat)x y:(CGFloat)y;
 - (void)setMode:(NSInteger)m;
 - (void)refresh;
+- (void)advanceCalendarContents;
+- (void)rewindCalendarContents;
 
 @property (nonatomic, weak) id<CalendarViewDelegate> calendarDelegate;
 @property (nonatomic, strong) NSDate *currentDate;

--- a/ios_calendar/Sources/CalendarView.h
+++ b/ios_calendar/Sources/CalendarView.h
@@ -61,6 +61,9 @@ typedef NS_ENUM(NSInteger, CalendarEvent)
 - (void)refresh;
 - (void)advanceCalendarContents;
 - (void)rewindCalendarContents;
+// Weekday indices start with Sunday = 0
+// to match the indices provided by the NSDateFormatter method shortWeekdaySymbols
+- (void)setPreferredWeekStartIndex:(NSInteger)index;
 
 @property (nonatomic, weak) id<CalendarViewDelegate> calendarDelegate;
 @property (nonatomic, strong) NSDate *currentDate;
@@ -85,7 +88,7 @@ typedef NS_ENUM(NSInteger, CalendarEvent)
 @property (nonatomic) CGFloat dayFontSize;
 @property (nonatomic) CGFloat headerFontSize;
 
-// Selection Display Options
+// Display Options
 @property (nonatomic, assign) BOOL shouldMarkSelectedDate;
 @property (nonatomic, assign) BOOL shouldMarkToday;
 @property (nonatomic, assign) BOOL shouldShowHeaders;

--- a/ios_calendar/Sources/CalendarView.h
+++ b/ios_calendar/Sources/CalendarView.h
@@ -86,5 +86,6 @@ typedef NS_ENUM(NSInteger, CalendarEvent)
 // Selection Display Options
 @property (nonatomic, assign) BOOL shouldMarkSelectedDate;
 @property (nonatomic, assign) BOOL shouldMarkToday;
+@property (nonatomic, assign) BOOL shouldShowHeaders;
 
 @end

--- a/ios_calendar/Sources/CalendarView.h
+++ b/ios_calendar/Sources/CalendarView.h
@@ -68,6 +68,7 @@ typedef NS_ENUM(NSInteger, CalendarEvent)
 @property (nonatomic, strong) UIColor *fontHeaderColor;
 @property (nonatomic, strong) UIColor *fontSelectedColor;
 @property (nonatomic, strong) UIColor *selectionColor;
+@property (nonatomic, strong) UIColor *todayColor;
 
 // Cell Size
 @property (nonatomic) CGFloat dayCellWidth;
@@ -81,5 +82,9 @@ typedef NS_ENUM(NSInteger, CalendarEvent)
 @property (nonatomic, strong) NSString *fontName;
 @property (nonatomic) CGFloat dayFontSize;
 @property (nonatomic) CGFloat headerFontSize;
+
+// Selection Display Options
+@property (nonatomic, assign) BOOL shouldMarkSelectedDate;
+@property (nonatomic, assign) BOOL shouldMarkToday;
 
 @end

--- a/ios_calendar/Sources/CalendarView.m
+++ b/ios_calendar/Sources/CalendarView.m
@@ -183,6 +183,7 @@ static const NSTimeInterval kCalendarViewSwipeMonthFadeOutTime = 0.6;
     
     self.shouldMarkSelectedDate = YES;
     self.shouldMarkToday = NO;
+    self.shouldShowHeaders = YES;
     
     event = CalendarEventNone;
     
@@ -448,7 +449,11 @@ static const NSTimeInterval kCalendarViewSwipeMonthFadeOutTime = 0.6;
     
 	NSString *year = [NSString stringWithFormat:@"%ld", (long)currentYear];
 	const CGFloat yearNameX = (self.dayCellWidth - CGRectGetHeight(cellFontBoundingBox)) * 0.5;
-    yearTitleRect = CGRectMake(yearNameX, 0, kCalendarViewYearLabelWidth, kCalendarViewYearLabelHeight);
+    if (self.shouldShowHeaders) {
+        yearTitleRect = CGRectMake(yearNameX, 0, kCalendarViewYearLabelWidth, kCalendarViewYearLabelHeight);
+    } else {
+        yearTitleRect = CGRectZero;
+    }
 	[year drawUsingRect:yearTitleRect withAttributes:attributesRedLeft];
 	
     if (mode != CalendarModeYears) {
@@ -456,7 +461,11 @@ static const NSTimeInterval kCalendarViewSwipeMonthFadeOutTime = 0.6;
         NSArray *monthNames = [formater standaloneMonthSymbols];
         NSString *monthName = monthNames[(currentMonth - 1)];
         const CGFloat monthNameX = (self.dayCellWidth + kCalendarViewDayCellOffset) * kCalendarViewDaysInWeek - kCalendarViewMonthLabelWidth - (self.dayCellWidth - CGRectGetHeight(cellFontBoundingBox));
-        monthTitleRect = CGRectMake(monthNameX, 0, kCalendarViewMonthLabelWidth, kCalendarViewMonthLabelHeight);
+        if (self.shouldShowHeaders) {
+            monthTitleRect = CGRectMake(monthNameX, 0, kCalendarViewMonthLabelWidth, kCalendarViewMonthLabelHeight);
+        } else {
+            monthTitleRect = CGRectZero;
+        }
         [monthName drawUsingRect:monthTitleRect withAttributes:attributesRedRight];
     }
 	

--- a/ios_calendar/Sources/CalendarView.m
+++ b/ios_calendar/Sources/CalendarView.m
@@ -85,6 +85,10 @@ static const NSTimeInterval kCalendarViewSwipeMonthFadeOutTime = 0.6;
 - (void)generateDayRects;
 - (void)generateMonthRects;
 - (void)generateYearRects;
+- (CGFloat)getEffectiveWeekDaysYOffset;
+- (CGFloat)getEffectiveDaysYOffset;
+- (CGFloat)getEffectiveMonthsYOffset;
+- (CGFloat)getEffectiveYearsYOffset;
 
 - (void)drawCircle:(CGRect)rect toContext:(CGContextRef *)context withColor:(UIColor *)color;
 - (void)drawRoundedRectangle:(CGRect)rect toContext:(CGContextRef *)context;
@@ -330,7 +334,7 @@ static const NSTimeInterval kCalendarViewSwipeMonthFadeOutTime = 0.6;
     currentDate = [calendar dateFromComponents:components];
     NSInteger weekday = [currentDate getWeekdayOfFirstDayOfMonth];
 	
-	const CGFloat yOffSet = kCalendarViewDaysYOffset;
+	const CGFloat yOffSet = [self getEffectiveDaysYOffset];
 	const CGFloat w = self.dayCellWidth;
 	const CGFloat h = self.dayCellHeight;
 	
@@ -365,7 +369,7 @@ static const NSTimeInterval kCalendarViewSwipeMonthFadeOutTime = 0.6;
     NSDateFormatter *formater = [NSDateFormatter new];
     NSArray *monthNames = [formater standaloneMonthSymbols];
     NSInteger index = 0;
-    CGFloat x, y = kCalendarViewMonthTitleOffsetY;
+    CGFloat x, y = [self getEffectiveMonthsYOffset];
     NSInteger xi = 0;
     for (NSString *monthName in monthNames) {
         x = xi * self.monthCellWidth;
@@ -394,7 +398,7 @@ static const NSTimeInterval kCalendarViewSwipeMonthFadeOutTime = 0.6;
         [years addObject:@(year)];
     }
     
-    CGFloat x, y = kCalendarViewYearTitleOffsetY;
+    CGFloat x, y = [self getEffectiveYearsYOffset];
     NSInteger xi = 0;
     for (NSNumber *obj in years) {
         x = xi * self.yearCellWidth;
@@ -411,6 +415,42 @@ static const NSTimeInterval kCalendarViewSwipeMonthFadeOutTime = 0.6;
             y += kCalendarViewYearYStep;
         }
     }
+}
+
+# pragma mark - Layout Calculations 
+
+- (CGFloat)getEffectiveWeekDaysYOffset
+{
+    if (self.shouldShowHeaders) {
+        return kCalendarViewWeekDaysYOffset;
+    } else {
+        return 0;
+    }
+}
+
+- (CGFloat)getEffectiveDaysYOffset
+{
+    if (self.shouldShowHeaders) {
+        return  kCalendarViewDaysYOffset;
+    } else {
+        return kCalendarViewDaysYOffset - kCalendarViewWeekDaysYOffset;
+    }
+}
+
+- (CGFloat)getEffectiveMonthsYOffset
+{
+    if (self.shouldShowHeaders) {
+        return kCalendarViewMonthTitleOffsetY;
+    } else {
+        return 0;
+    }
+}
+
+- (CGFloat)getEffectiveYearsYOffset
+{
+    if (self.shouldShowHeaders) {
+        return kCalendarViewYearTitleOffsetY;
+    } else return 0;
 }
 
 #pragma mark - Drawing
@@ -565,7 +605,7 @@ static const NSTimeInterval kCalendarViewSwipeMonthFadeOutTime = 0.6;
 									 withAlignment:NSTextAlignmentFromCTTextAlignment(kCTCenterTextAlignment)];
 	
 	CGFloat x = 0;
-	CGFloat y = kCalendarViewWeekDaysYOffset;
+	CGFloat y = [self getEffectiveWeekDaysYOffset];
 	const CGFloat w = self.dayCellWidth;
 	const CGFloat h = self.dayCellHeight;
 	for (int i = 1; i < kCalendarViewDaysInWeek; ++i) {

--- a/ios_calendar/Sources/CalendarView.m
+++ b/ios_calendar/Sources/CalendarView.m
@@ -66,6 +66,8 @@ static const NSTimeInterval kCalendarViewSwipeMonthFadeOutTime = 0.6;
     NSInteger currentMonth;
     NSInteger currentYear;
     
+    int preferredWeekStartIndex;
+    
     NSInteger todayDay;
     NSInteger todayMonth;
     NSInteger todayYear;
@@ -190,7 +192,7 @@ static const NSTimeInterval kCalendarViewSwipeMonthFadeOutTime = 0.6;
     
     self.shouldMarkSelectedDate = YES;
     self.shouldMarkToday = NO;
-    self.shouldShowHeaders = YES;
+    self.shouldShowHeaders = NO;
     
     event = CalendarEventNone;
     
@@ -207,6 +209,8 @@ static const NSTimeInterval kCalendarViewSwipeMonthFadeOutTime = 0.6;
     todayDay = [components day];
     todayMonth = [components month];
     todayYear = [components year];
+    
+    preferredWeekStartIndex = 1; // This is Monday, from [dateFormatter shortWeekdaySymbols]
     
     UISwipeGestureRecognizer *left = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(leftSwipe:)];
     [left setDirection:UISwipeGestureRecognizerDirectionLeft];
@@ -344,7 +348,7 @@ static const NSTimeInterval kCalendarViewSwipeMonthFadeOutTime = 0.6;
 	CGFloat x = 0;
 	CGFloat y = yOffSet;
 	
-	NSInteger xi = weekday - 1;
+	NSInteger xi = weekday - preferredWeekStartIndex;
 	NSInteger yi = 0;
 	
 	for (NSInteger i = 1; i <= lastDayOfMonth; ++i) {
@@ -611,15 +615,20 @@ static const NSTimeInterval kCalendarViewSwipeMonthFadeOutTime = 0.6;
 	CGFloat y = [self getEffectiveWeekDaysYOffset];
 	const CGFloat w = self.dayCellWidth;
 	const CGFloat h = self.dayCellHeight;
-	for (int i = 1; i < kCalendarViewDaysInWeek; ++i) {
-		x = (i - 1) * (self.dayCellWidth + kCalendarViewDayCellOffset);
+	for (int i = preferredWeekStartIndex; i < kCalendarViewDaysInWeek; ++i) {
+        int adjustedIndex = i - preferredWeekStartIndex;
+		x = adjustedIndex * (self.dayCellWidth + kCalendarViewDayCellOffset);
 		NSString *str = [NSString stringWithFormat:@"%@", weekdayNames[i]];
 		[str drawUsingRect:CGRectMake(x, y, w, h) withAttributes:attrs];
 	}
-	
-	NSString *strSunday = [NSString stringWithFormat:@"%@",weekdayNames[0]];
-	x = (kCalendarViewDaysInWeek - 1) * (self.dayCellWidth + kCalendarViewDayCellOffset);
-	[strSunday drawUsingRect:CGRectMake(x, y, w, h) withAttributes:attrs];
+    
+    for (int i = 0; i < preferredWeekStartIndex; ++i) {
+        int adjustedIndex = kCalendarViewDaysInWeek - (preferredWeekStartIndex - i);
+        x = adjustedIndex * (self.dayCellWidth + kCalendarViewDayCellOffset);
+        NSString *str = [NSString stringWithFormat:@"%@", weekdayNames[i]];
+        [str drawUsingRect:CGRectMake(x, y, w, h) withAttributes:attrs];
+    }
+
 }
 
 #pragma mark - Change date event
@@ -872,6 +881,11 @@ static const NSTimeInterval kCalendarViewSwipeMonthFadeOutTime = 0.6;
 										  }
 										  completion:nil];
 					 }];
+}
+
+- (void)setPreferredWeekStartIndex:(NSInteger)index
+{
+    preferredWeekStartIndex = (int)index;
 }
 
 @end

--- a/ios_calendar/Sources/CalendarView.m
+++ b/ios_calendar/Sources/CalendarView.m
@@ -102,6 +102,9 @@ static const NSTimeInterval kCalendarViewSwipeMonthFadeOutTime = 0.6;
 
 - (void)changeDateEvent;
 
+- (void)advanceCalendarContentsWithEvent:(CalendarEvent)eventType;
+- (void)rewindCalendarContentsWithEvent:(CalendarEvent)eventType;
+
 - (NSDictionary *)generateAttributes:(NSString *)fontName withFontSize:(CGFloat)fontSize withColor:(UIColor *)color withAlignment:(NSTextAlignment)textAlignment;
 - (BOOL)checkPoint:(CGPoint)point inArray:(NSMutableArray *)array andSetValue:(NSInteger *)value;
 - (void)fade;
@@ -636,6 +639,18 @@ static const NSTimeInterval kCalendarViewSwipeMonthFadeOutTime = 0.6;
 
 - (void)advanceCalendarContents
 {
+    [self advanceCalendarContentsWithEvent:CalendarEventNone];
+}
+
+- (void)rewindCalendarContents
+{
+    [self rewindCalendarContentsWithEvent:CalendarEventNone];
+}
+
+- (void)advanceCalendarContentsWithEvent:(CalendarEvent)eventType
+{
+    event = eventType;
+    
     switch (type) {
         case CalendarViewTypeDay:
         {
@@ -670,8 +685,10 @@ static const NSTimeInterval kCalendarViewSwipeMonthFadeOutTime = 0.6;
     [self fade];
 }
 
-- (void)rewindCalendarContents
+- (void)rewindCalendarContentsWithEvent:(CalendarEvent)eventType
 {
+    event = eventType;
+    
     switch (type) {
         case CalendarViewTypeDay:
         {
@@ -710,16 +727,12 @@ static const NSTimeInterval kCalendarViewSwipeMonthFadeOutTime = 0.6;
 
 - (void)leftSwipe:(UISwipeGestureRecognizer *)recognizer
 {
-    event = CalendarEventSwipeLeft;
-    
-    [self advanceCalendarContents];
+    [self advanceCalendarContentsWithEvent:CalendarEventSwipeLeft];
 }
 
 - (void)rightSwipe:(UISwipeGestureRecognizer *)recognizer
 {
-    event = CalendarEventSwipeRight;
-    
-    [self rewindCalendarContents];
+    [self rewindCalendarContentsWithEvent:CalendarEventSwipeRight];
 }
 
 - (void)pinch:(UIPinchGestureRecognizer *)recognizer

--- a/ios_calendar/Sources/CalendarView.m
+++ b/ios_calendar/Sources/CalendarView.m
@@ -66,6 +66,10 @@ static const NSTimeInterval kCalendarViewSwipeMonthFadeOutTime = 0.6;
     NSInteger currentMonth;
     NSInteger currentYear;
     
+    NSInteger todayDay;
+    NSInteger todayMonth;
+    NSInteger todayYear;
+    
     NSMutableArray *dayRects;
     NSMutableArray *monthRects;
     NSMutableArray *yearRects;
@@ -82,7 +86,7 @@ static const NSTimeInterval kCalendarViewSwipeMonthFadeOutTime = 0.6;
 - (void)generateMonthRects;
 - (void)generateYearRects;
 
-- (void)drawCircle:(CGRect)rect toContext:(CGContextRef *)context;
+- (void)drawCircle:(CGRect)rect toContext:(CGContextRef *)context withColor:(UIColor *)color;
 - (void)drawRoundedRectangle:(CGRect)rect toContext:(CGContextRef *)context;
 - (void)drawWeekDays;
 
@@ -174,7 +178,11 @@ static const NSTimeInterval kCalendarViewSwipeMonthFadeOutTime = 0.6;
     self.fontHeaderColor = [UIColor redColor];
     self.fontSelectedColor = [UIColor whiteColor];
     self.selectionColor = [UIColor redColor];
+    self.todayColor = [UIColor redColor];
     bgColor = [UIColor whiteColor];
+    
+    self.shouldMarkSelectedDate = YES;
+    self.shouldMarkToday = NO;
     
     event = CalendarEventNone;
     
@@ -187,6 +195,10 @@ static const NSTimeInterval kCalendarViewSwipeMonthFadeOutTime = 0.6;
     currentDay = [components day];
     currentMonth = [components month];
     currentYear = [components year];
+    
+    todayDay = [components day];
+    todayMonth = [components month];
+    todayYear = [components year];
     
     UISwipeGestureRecognizer *left = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:@selector(leftSwipe:)];
     [left setDirection:UISwipeGestureRecognizerDirectionLeft];
@@ -483,14 +495,21 @@ static const NSTimeInterval kCalendarViewSwipeMonthFadeOutTime = 0.6;
             CGRect rectText = rect.frame;
             rectText.origin.y = rectText.origin.y + ((CGRectGetHeight(rectText) - CGRectGetHeight(cellFontBoundingBox)) * 0.5);
             
-            if (rect.value == currentValue) {
+            if (rect.value == currentValue && self.shouldMarkSelectedDate) {
                 if (type == CalendarViewTypeDay) {
-                    [self drawCircle:rect.frame toContext:&context];
+                    [self drawCircle:rect.frame toContext:&context withColor:self.selectionColor];
                 }
                 else {
                     [self drawRoundedRectangle:rect.frame toContext:&context];
                 }
                 
+                attrs = attributesWhite;
+            } else if (type == CalendarViewTypeDay &&
+                       rect.value == todayDay &&
+                       currentMonth == todayMonth &&
+                       currentYear == todayYear &&
+                       self.shouldMarkToday) {
+                [self drawCircle:rect.frame toContext:&context withColor:self.todayColor];
                 attrs = attributesWhite;
             }
             else {
@@ -502,9 +521,9 @@ static const NSTimeInterval kCalendarViewSwipeMonthFadeOutTime = 0.6;
     }
 }
 
-- (void)drawCircle:(CGRect)rect toContext:(CGContextRef *)context
+- (void)drawCircle:(CGRect)rect toContext:(CGContextRef *)context withColor:(UIColor *)color
 {
-    CGContextSetFillColorWithColor(*context, self.selectionColor.CGColor);
+    CGContextSetFillColorWithColor(*context, color.CGColor);
     CGContextFillEllipseInRect(*context, rect);
 }
 

--- a/ios_calendar/Sources/CalendarView.m
+++ b/ios_calendar/Sources/CalendarView.m
@@ -632,12 +632,10 @@ static const NSTimeInterval kCalendarViewSwipeMonthFadeOutTime = 0.6;
     }
 }
 
-#pragma mark - Gestures
+#pragma mark - Advance/Rewind Calendar Contents
 
-- (void)leftSwipe:(UISwipeGestureRecognizer *)recognizer
+- (void)advanceCalendarContents
 {
-    event = CalendarEventSwipeLeft;
-    
     switch (type) {
         case CalendarViewTypeDay:
         {
@@ -651,31 +649,29 @@ static const NSTimeInterval kCalendarViewSwipeMonthFadeOutTime = 0.6;
             
             [self generateDayRects];
         }
-        break;
+            break;
         case CalendarViewTypeMonth:
         {
             ++currentYear;
         }
-        break;
+            break;
         case CalendarViewTypeYear:
         {
             currentYear += kCalendarViewYearsAround;
             [self generateYearRects];
         }
-        break;
+            break;
             
         default:
             break;
     }
-	
-	[self changeDateEvent];
-	[self fade];
+    
+    [self changeDateEvent];
+    [self fade];
 }
 
-- (void)rightSwipe:(UISwipeGestureRecognizer *)recognizer
+- (void)rewindCalendarContents
 {
-    event = CalendarEventSwipeRight;
-    
     switch (type) {
         case CalendarViewTypeDay:
         {
@@ -689,25 +685,41 @@ static const NSTimeInterval kCalendarViewSwipeMonthFadeOutTime = 0.6;
             
             [self generateDayRects];
         }
-        break;
+            break;
         case CalendarViewTypeMonth:
         {
             --currentYear;
         }
-        break;
+            break;
         case CalendarViewTypeYear:
         {
             currentYear -= kCalendarViewYearsAround;
             [self generateYearRects];
         }
-        break;
+            break;
             
         default:
             break;
     }
     
-	[self changeDateEvent];
-	[self fade];
+    [self changeDateEvent];
+    [self fade];
+}
+
+#pragma mark - Gestures
+
+- (void)leftSwipe:(UISwipeGestureRecognizer *)recognizer
+{
+    event = CalendarEventSwipeLeft;
+    
+    [self advanceCalendarContents];
+}
+
+- (void)rightSwipe:(UISwipeGestureRecognizer *)recognizer
+{
+    event = CalendarEventSwipeRight;
+    
+    [self rewindCalendarContents];
 }
 
 - (void)pinch:(UIPinchGestureRecognizer *)recognizer


### PR DESCRIPTION
As I noted in the issue, this just primarily adds some more UI options for the component. Specifically, there are now options to

1)  Mark today's date. This can be done in addition to or instead of marking the currently selected date. Default is to only mark the currently selected date.

2) Collapse the month and year headers. Default is to leave them in place. 

3) Set a preferred starting day of the week. Default is Monday. 

Additionally, there are now exposed methods to move the calendar content forward and backwards (which previously was only possible via swiping). 

There shouldn't be any changes in expected behavior, since it was pretty cool to begin with. There's  just some more flexibility for those who want it.  